### PR TITLE
better flowtype on withLibcore

### DIFF
--- a/src/helpers/withLibcore.js
+++ b/src/helpers/withLibcore.js
@@ -1,31 +1,30 @@
 // @flow
 
+import invariant from 'invariant'
+
 const core = require('@ledgerhq/ledger-core')
 
-let walletPool = null
+let walletPoolInstance: ?Object = null
 let queue = Promise.resolve()
 
 // TODO: `core` and `NJSWalletPool` should be typed
-type Job = (Object, Object) => any
+type Job<A> = (Object, Object) => Promise<A>
 
-export default function withLibcore(job: Job) {
-  if (!walletPool) {
-    walletPool = core.instanciateWalletPool({
+export default function withLibcore<A>(job: Job<A>): Promise<A> {
+  if (!walletPoolInstance) {
+    walletPoolInstance = core.instanciateWalletPool({
       // sqlite files will be located in the app local data folder
       dbPath: process.env.LEDGER_LIVE_SQLITE_PATH,
     })
   }
-  // $FlowFixMe WTF is happening here, dudes.
-  queue = queue.then(async () => {
-    try {
-      if (!walletPool) {
-        throw new Error('wallet pool not instanciated. this should not happen')
-      }
-      return job(core, walletPool)
-    } catch (e) {
-      console.log(`withLibCore: Error in job`, e) // eslint-disable-line no-console
-      return Promise.resolve()
-    }
+  const walletPool = walletPoolInstance
+  invariant(walletPool, 'core.instanciateWalletPool returned null !!')
+
+  const p = queue.then(() => job(core, walletPool))
+
+  queue = p.catch(e => {
+    console.warn(`withLibCore: Error in job`, e)
   })
-  return queue
+
+  return p
 }


### PR DESCRIPTION
(impl note: i could have invariant() inside each .then() but as you said, it should never happen so we can make it once, just need it to be a `const` / scoped variable to really prove to flow it can't be changed.)

this basically will improve type safety on withLibcore usage, typically this:

<img width="645" alt="capture d ecran 2018-06-03 a 17 42 08" src="https://user-images.githubusercontent.com/211411/40888336-134900ce-6756-11e8-9528-4e9de4bd9d93.png">

hope it's not too much a struggle but the benefit is real